### PR TITLE
Split large grouping of dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,20 @@ updates:
       - dependency-type: "direct"
       - dependency-type: "indirect"
     groups:
-      all-npm:
+      actions:
         patterns:
-          - "*"
+          - "@actions/*"
+      octokit:
+        patterns:
+          - "@octokit/*"
+      linting:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+      build-and-test:
+        patterns:
+          - "esbuild"
+          - "vitest"
+          - "@vitest/*"
+          - "nock"


### PR DESCRIPTION
Grouping all updates in one PR makes it harder to validate the changes and fixing if CI fails

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
